### PR TITLE
Use latest version of GitBook

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,5 +1,5 @@
 {
-    "gitbook": "2.0.1",
+    "gitbook": "*",
     "plugins": ["edit-link", "versions", "code_tomorrow_scheme"],
     "pluginsConfig": {
             "edit-link": {


### PR DESCRIPTION
Since we are pushing a new version of GitBook every week or two ([ChangeLog](https://github.com/GitbookIO/gitbook/blob/master/CHANGES.md)), and keeping gitbook.com on sync with the latest version; it's a better practice to use the `*` as a GitBook version if your book doesn't incompatibilities with latest releases.
